### PR TITLE
updates

### DIFF
--- a/libgambatte/src/cpu.cpp
+++ b/libgambatte/src/cpu.cpp
@@ -996,15 +996,13 @@ void CPU::process(unsigned long const cycles) {
 
 				// halt (4 cycles):
 			case 0x76:
-				if (!mem_.ime()
-					&& (   mem_.ff_read(0x0F, cycleCounter)
-					     & mem_.ff_read(0xFF, cycleCounter) & 0x1F)) {
-					if (mem_.isCgb())
-						cycleCounter += 4;
+				if (mem_.ff_read(0x0F, cycleCounter) & mem_.ff_read(0xFF, cycleCounter) & 0x1F) {
+					if (mem_.ime())
+						pc = (pc - 1) & 0xFFFF;
 					else
 						skip_ = true;
 				} else {
-					mem_.halt();
+					mem_.halt(cycleCounter);
 
 					if (cycleCounter < mem_.nextEventTime()) {
 						unsigned long cycles = mem_.nextEventTime() - cycleCounter;

--- a/libgambatte/src/cpu.cpp
+++ b/libgambatte/src/cpu.cpp
@@ -590,16 +590,6 @@ void CPU::process(unsigned long const cycles) {
 				// Halt CPU and LCD display until button pressed:
 			case 0x10:
                 {
-                    unsigned char followingByte;
-                    PEEK(followingByte, pc);
-                    pc = (pc + 1) & 0xFFFF;
-                    
-                    // if(followingByte != 0x00) {
-                        ////corrupted stop
-                        // mem_.di();
-                        // mem_.blackScreen();
-                    // }
-
                     cycleCounter = mem_.stop(cycleCounter);
 
                     if (cycleCounter < mem_.nextEventTime()) {

--- a/libgambatte/src/initstate.cpp
+++ b/libgambatte/src/initstate.cpp
@@ -1201,12 +1201,14 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const gbaCgbM
 	state.mem.ioamhram.ptr[0x144] = 0x00;
 
 	state.mem.divLastUpdate = 0;
+	state.mem.timaBasetime = 0;
 	state.mem.timaLastUpdate = 0;
 	state.mem.tmatime = disabled_time;
 	state.mem.nextSerialtime = disabled_time;
 	state.mem.lastOamDmaUpdate = disabled_time;
 	state.mem.unhaltTime = disabled_time;
 	state.mem.minIntTime = 0;
+	state.mem.halttime = 0;
 	state.mem.rombank = 1;
 	state.mem.dmaSource = 0;
 	state.mem.dmaDestination = 0;
@@ -1218,6 +1220,7 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const gbaCgbM
 	state.mem.rambankMode = false;
 	state.mem.hdmaTransfer = false;
 	state.mem.gbIsCgb = cgb;
+	state.mem.stopped = false;
 
 
 	for (int i = 0x00; i < 0x40; i += 0x02) {

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -172,6 +172,9 @@ unsigned long Memory::event(unsigned long cc) {
 	case intevent_unhalt:
 		intreq_.unhalt();
 		intreq_.setEventTime<intevent_unhalt>(disabled_time);
+		nontrivial_ff_write(0xFF04, 0, cc);
+		pc_ = (pc_ + 1) & 0xFFFF;
+		cc += 4;
 		break;
 	case intevent_end:
 		intreq_.setEventTime<intevent_end>(disabled_time - 1);
@@ -330,7 +333,7 @@ unsigned long Memory::event(unsigned long cc) {
 }
 
 unsigned long Memory::stop(unsigned long cc) {
-	cc += 4 + 4 * isDoubleSpeed();
+	cc += 4;
 
 	if (ioamhram_[0x14D] & isCgb()) {
 		psg_.generateSamples(cc, isDoubleSpeed());
@@ -347,7 +350,7 @@ unsigned long Memory::stop(unsigned long cc) {
 				   : (intreq_.eventTime(intevent_end) - cc) >> 1));
 		}
         intreq_.halt();
-        intreq_.setEventTime<intevent_unhalt>(cc + 0x20000 + isDoubleSpeed() * 8);
+        intreq_.setEventTime<intevent_unhalt>(cc + 0x20000);
 	}
     else {
         
@@ -358,7 +361,7 @@ unsigned long Memory::stop(unsigned long cc) {
         }
         else {
             intreq_.halt();
-            intreq_.setEventTime<intevent_unhalt>(cc + 0x20000 + isDoubleSpeed() * 8);
+            intreq_.setEventTime<intevent_unhalt>(cc + 0x20000);
         }
     }
 

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -667,7 +667,7 @@ void Memory::nontrivial_ff_write(unsigned const p, unsigned data, unsigned long 
 		break;
 	case 0x07:
 		data |= 0xF8;
-		tima_.setTac(data, cc, TimaInterruptRequester(intreq_));
+		tima_.setTac(data, cc, TimaInterruptRequester(intreq_), gbIsCgb_);
 		break;
 	case 0x0F:
 		updateIrqs(cc);

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -60,6 +60,7 @@ unsigned long Memory::saveState(SaveState &state, unsigned long cc) {
 	state.mem.divLastUpdate = divLastUpdate_;
 	state.mem.nextSerialtime = intreq_.eventTime(intevent_serial);
 	state.mem.unhaltTime = intreq_.eventTime(intevent_unhalt);
+	state.mem.halttime = halttime_;
 	state.mem.lastOamDmaUpdate = lastOamDmaUpdate_;
 	state.mem.dmaSource = dmaSource_;
 	state.mem.dmaDestination = dmaDestination_;
@@ -68,6 +69,7 @@ unsigned long Memory::saveState(SaveState &state, unsigned long cc) {
 	state.mem.cgbSwitching = cgbSwitching_;
 	state.mem.agbMode = agbMode_;
 	state.mem.gbIsCgb = gbIsCgb_;
+	state.mem.stopped = stopped_;
 
 	intreq_.saveState(state);
 	cart_.saveState(state);
@@ -87,6 +89,7 @@ void Memory::loadState(SaveState const &state) {
 	cgbSwitching_ = state.mem.cgbSwitching;
 	agbMode_ = state.mem.agbMode;
 	gbIsCgb_ = state.mem.gbIsCgb;
+	stopped_ = state.mem.stopped;
 	psg_.loadState(state);
 	lcd_.loadState(state, state.mem.oamDmaPos < 0xA0 ? cart_.rdisabledRam() : ioamhram_);
 	tima_.loadState(state, TimaInterruptRequester(intreq_));
@@ -98,6 +101,7 @@ void Memory::loadState(SaveState const &state) {
 		? state.mem.nextSerialtime
 		: state.cpu.cycleCounter);
 	intreq_.setEventTime<intevent_unhalt>(state.mem.unhaltTime);
+	halttime_ = state.mem.halttime;
 	lastOamDmaUpdate_ = state.mem.lastOamDmaUpdate;
 	dmaSource_ = state.mem.dmaSource;
 	dmaDestination_ = state.mem.dmaDestination;

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -657,6 +657,7 @@ void Memory::nontrivial_ff_write(unsigned const p, unsigned data, unsigned long 
 	case 0x04:
 		ioamhram_[0x104] = 0;
 		divLastUpdate_ = cc;
+		tima_.resTac(cc, TimaInterruptRequester(intreq_));
 		return;
 	case 0x05:
 		tima_.setTima(data, cc, TimaInterruptRequester(intreq_));

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -289,6 +289,11 @@ unsigned long Memory::event(unsigned long cc) {
 		lcd_.update(cc);
 		break;
 	case intevent_interrupts:
+		if (stopped_) {
+			intreq_.setEventTime<intevent_interrupts>(disabled_time);
+			break;
+		}
+
 		if (halted()) {
 			if (gbIsCgb_ || (!gbIsCgb_ && cc <= halttime_ + 4))
 				cc += 4;
@@ -352,18 +357,10 @@ unsigned long Memory::stop(unsigned long cc) {
         intreq_.halt();
         intreq_.setEventTime<intevent_unhalt>(cc + 0x20000);
 	}
-    else {
-        
-        if((ioamhram_[0x100] & 0x30) == 0x30) {
-            // hang if a joypad press can't come
-            di();
-            intreq_.halt();
-        }
-        else {
-            intreq_.halt();
-            intreq_.setEventTime<intevent_unhalt>(cc + 0x20000);
-        }
-    }
+	else {
+		stopped_ = true;
+		intreq_.halt();
+	}
 
 	return cc;
 }

--- a/libgambatte/src/memory.cpp
+++ b/libgambatte/src/memory.cpp
@@ -290,7 +290,7 @@ unsigned long Memory::event(unsigned long cc) {
 		break;
 	case intevent_interrupts:
 		if (halted()) {
-			if (gbIsCgb_)
+			if (gbIsCgb_ || (!gbIsCgb_ && cc <= halttime_ + 4))
 				cc += 4;
 
 			intreq_.unhalt();

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -157,6 +157,7 @@ private:
     unsigned short &sp_;
 	unsigned short &pc_;
 	unsigned long halttime_;
+	bool stopped_;
 
 	void decEventCycles(IntEventId eventId, unsigned long dec);
 	void oamDmaInitSetup();

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -64,7 +64,7 @@ public:
 		return (cc - intreq_.eventTime(intevent_blit)) >> isDoubleSpeed();
 	}
 
-	void halt() { intreq_.halt(); }
+	void halt(unsigned long cycleCounter) { halttime_ = cycleCounter; intreq_.halt(); }
 	void ei(unsigned long cycleCounter) { if (!ime()) { intreq_.ei(cycleCounter); } }
 	void di() { intreq_.di(); }
 	
@@ -156,6 +156,7 @@ private:
 	bool gbIsCgb_;
     unsigned short &sp_;
 	unsigned short &pc_;
+	unsigned long halttime_;
 
 	void decEventCycles(IntEventId eventId, unsigned long dec);
 	void oamDmaInitSetup();

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -63,12 +63,14 @@ struct SaveState {
 		Ptr<unsigned char> wram;
 		Ptr<unsigned char> ioamhram;
 		unsigned long divLastUpdate;
+		unsigned long timaBasetime;
 		unsigned long timaLastUpdate;
 		unsigned long tmatime;
 		unsigned long nextSerialtime;
 		unsigned long lastOamDmaUpdate;
 		unsigned long minIntTime;
 		unsigned long unhaltTime;
+		unsigned long halttime;
 		unsigned short rombank;
 		unsigned short dmaSource;
 		unsigned short dmaDestination;
@@ -83,6 +85,7 @@ struct SaveState {
 		unsigned char /*bool*/ cgbSwitching;
 		unsigned char /*bool*/ agbMode;
 		unsigned char /*bool*/ gbIsCgb;
+		unsigned char /*bool*/ stopped;
 	} mem;
 
 	struct PPU {

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -231,12 +231,14 @@ SaverList::SaverList() {
 	{ static char const label[] = { w,r,a,m,       NUL }; ADDPTR(mem.wram); }
 	{ static char const label[] = { h,r,a,m,       NUL }; ADDPTR(mem.ioamhram); }
 	{ static char const label[] = { l,d,i,v,u,p,   NUL }; ADD(mem.divLastUpdate); }
+	{ static char const label[] = { t,i,m,a,b,t,   NUL }; ADD(mem.timaBasetime); }
 	{ static char const label[] = { l,t,i,m,a,u,p, NUL }; ADD(mem.timaLastUpdate); }
 	{ static char const label[] = { t,m,a,t,i,m,e, NUL }; ADD(mem.tmatime); }
 	{ static char const label[] = { s,e,r,i,a,l,t, NUL }; ADD(mem.nextSerialtime); }
 	{ static char const label[] = { l,o,d,m,a,u,p, NUL }; ADD(mem.lastOamDmaUpdate); }
 	{ static char const label[] = { m,i,n,i,n,t,t, NUL }; ADD(mem.minIntTime); }
 	{ static char const label[] = { u,n,h,a,l,t,t, NUL }; ADD(mem.unhaltTime); }
+	{ static char const label[] = { h,a,l,t,t,     NUL }; ADD(mem.halttime); }
 	{ static char const label[] = { r,o,m,b,a,n,k, NUL }; ADD(mem.rombank); }
 	{ static char const label[] = { d,m,a,s,r,c,   NUL }; ADD(mem.dmaSource); }
 	{ static char const label[] = { d,m,a,d,s,t,   NUL }; ADD(mem.dmaDestination); }
@@ -250,6 +252,7 @@ SaverList::SaverList() {
 	{ static char const label[] = { a,g,b,m,o,d,e, NUL }; ADD(mem.agbMode); }
 	{ static char const label[] = { c,g,b,s,w,     NUL }; ADD(mem.cgbSwitching); }
 	{ static char const label[] = { b,i,o,s,c,g,b, NUL }; ADD(mem.gbIsCgb); }
+	{ static char const label[] = { s,t,o,p,p,e,d, NUL }; ADD(mem.stopped); }
 	{ static char const label[] = { b,g,p,         NUL }; ADDPTR(ppu.bgpData); }
 	{ static char const label[] = { o,b,j,p,       NUL }; ADDPTR(ppu.objpData); }
 	{ static char const label[] = { s,p,o,s,b,u,f, NUL }; ADDPTR(ppu.oamReaderBuf); }

--- a/libgambatte/src/tima.cpp
+++ b/libgambatte/src/tima.cpp
@@ -121,7 +121,7 @@ void Tima::setTma(unsigned const data, unsigned long const cc, TimaInterruptRequ
 	tma_ = data;
 }
 
-void Tima::setTac(unsigned const data, unsigned long const cc, TimaInterruptRequester timaIrq) {
+void Tima::setTac(unsigned const data, unsigned long const cc, TimaInterruptRequester timaIrq, bool gbIsCgb) {
 	if (tac_ ^ data) {
 		unsigned long nextIrqEventTime = timaIrq.nextIrqEventTime();
 
@@ -145,6 +145,11 @@ void Tima::setTac(unsigned const data, unsigned long const cc, TimaInterruptRequ
 		if (data & 4) {
 			unsigned long diff = cc - basetime_;
 
+			if (gbIsCgb) {
+				if (((diff >> (timaClock[tac_ & 3] - 1)) & 1) == 1 && ((diff >> (timaClock[data & 3] - 1)) & 1) == 0)
+					tima_++;
+			}
+
 			lastUpdate_ = basetime_ + ((diff >> timaClock[data & 3]) << timaClock[data & 3]);
 			nextIrqEventTime = lastUpdate_ + ((256u - tima_) << timaClock[data & 3]) + 3;
 		}
@@ -159,8 +164,8 @@ void Tima::resTac(unsigned long const cc, TimaInterruptRequester timaIrq) {
 	basetime_ = cc;
 
 	if (tac_ & 0x04) {
-		setTac(tac_ & ~0x04, cc, timaIrq);
-		setTac(tac_ | 0x04, cc, timaIrq);
+		setTac(tac_ & ~0x04, cc, timaIrq, false);
+		setTac(tac_ | 0x04, cc, timaIrq, false);
 	}
 }
 

--- a/libgambatte/src/tima.cpp
+++ b/libgambatte/src/tima.cpp
@@ -143,7 +143,9 @@ void Tima::setTac(unsigned const data, unsigned long const cc, TimaInterruptRequ
 		}
 
 		if (data & 4) {
-			lastUpdate_ = (cc >> timaClock[data & 3]) << timaClock[data & 3];
+			unsigned long diff = cc - basetime_;
+
+			lastUpdate_ = basetime_ + ((diff >> timaClock[data & 3]) << timaClock[data & 3]);
 			nextIrqEventTime = lastUpdate_ + ((256u - tima_) << timaClock[data & 3]) + 3;
 		}
 
@@ -151,6 +153,15 @@ void Tima::setTac(unsigned const data, unsigned long const cc, TimaInterruptRequ
 	}
 
 	tac_ = data;
+}
+
+void Tima::resTac(unsigned long const cc, TimaInterruptRequester timaIrq) {
+	basetime_ = cc;
+
+	if (tac_ & 0x04) {
+		setTac(tac_ & ~0x04, cc, timaIrq);
+		setTac(tac_ | 0x04, cc, timaIrq);
+	}
 }
 
 unsigned Tima::tima(unsigned long cc) {

--- a/libgambatte/src/tima.cpp
+++ b/libgambatte/src/tima.cpp
@@ -33,11 +33,13 @@ Tima::Tima()
 }
 
 void Tima::saveState(SaveState &state) const {
+	state.mem.timaBasetime = basetime_;
 	state.mem.timaLastUpdate = lastUpdate_;
 	state.mem.tmatime = tmatime_;
 }
 
 void Tima::loadState(SaveState const &state, TimaInterruptRequester timaIrq) {
+	basetime_ = state.mem.timaBasetime;
 	lastUpdate_ = state.mem.timaLastUpdate;
 	tmatime_ = state.mem.tmatime;
 	tima_ = state.mem.ioamhram.get()[0x105];

--- a/libgambatte/src/tima.h
+++ b/libgambatte/src/tima.h
@@ -42,7 +42,7 @@ public:
 	void resetCc(unsigned long oldCc, unsigned long newCc, TimaInterruptRequester timaIrq);
 	void setTima(unsigned tima, unsigned long cc, TimaInterruptRequester timaIrq);
 	void setTma(unsigned tma, unsigned long cc, TimaInterruptRequester timaIrq);
-	void setTac(unsigned tac, unsigned long cc, TimaInterruptRequester timaIrq);
+	void setTac(unsigned tac, unsigned long cc, TimaInterruptRequester timaIrq, bool gbIsCgb);
 	void resTac(unsigned long cc, TimaInterruptRequester timaIrq);
 	unsigned tima(unsigned long cc);
 	void doIrqEvent(TimaInterruptRequester timaIrq);

--- a/libgambatte/src/tima.h
+++ b/libgambatte/src/tima.h
@@ -43,10 +43,12 @@ public:
 	void setTima(unsigned tima, unsigned long cc, TimaInterruptRequester timaIrq);
 	void setTma(unsigned tma, unsigned long cc, TimaInterruptRequester timaIrq);
 	void setTac(unsigned tac, unsigned long cc, TimaInterruptRequester timaIrq);
+	void resTac(unsigned long cc, TimaInterruptRequester timaIrq);
 	unsigned tima(unsigned long cc);
 	void doIrqEvent(TimaInterruptRequester timaIrq);
 
 private:
+	unsigned long basetime_;
 	unsigned long lastUpdate_;
 	unsigned long tmatime_;
 	unsigned char tima_;


### PR DESCRIPTION
- fixes Crystal JP TIDs
- fixes Yellow TAS
- prevents abusing stop emulation for ACE (Yellow JP, Yellow)

old savestates die because of the stop stuff, can only take first four commits if you want to preserve