### PR TITLE
Fix build scripts and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To build it on Debian, do:
     sudo apt install build-essential git scons zlib1g-dev qt5-default libqt5x11extras5-dev libxrandr-dev libxv-dev libasound2-dev
     git clone https://github.com/Dabomstew/gambatte-speedrun
     cd gambatte-speedrun
-    scripts/build_qt.sh
+    sh scripts/build_qt.sh
     cp gambatte_qt/bin/gambatte_qt SOMEWHERE/gsr # or w/e
     
 To build the "non-PSR" version with additional selectable platforms (GB, GBC, GBA, SGB2), create `gambatte_qt/src/platforms.pri` with the following:

--- a/scripts/build_qt.sh
+++ b/scripts/build_qt.sh
@@ -4,4 +4,4 @@ echo "cd libgambatte && scons"
 (cd libgambatte && scons) || exit
 
 echo "cd gambatte_qt && make"
-(cd gambatte_qt && rm -f bin/gambatte_qt.exe && make)
+(cd gambatte_qt && rm -f bin/gambatte_qt.exe && qmake && make)

--- a/scripts/build_qt_only.sh
+++ b/scripts/build_qt_only.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "cd gambatte_qt && make"
-(cd gambatte_qt && rm -f bin/gambatte_qt.exe && make)
+(cd gambatte_qt && rm -f bin/gambatte_qt.exe && qmake && make)


### PR DESCRIPTION
`build_qt.sh` and `build_qt_only.sh` are missing a `qmake` command, meaning that the `make` command won't find a makefile. Additionally, the build instructions in README.md don't work since the scripts don't have executable permissions by default.