### PR TITLE
shared library updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Makefile*
 *.Release
 gambatte_sdl/gambatte_sdl
 gambatte_qt/src/moc_*.cpp
+gambatte_qt/src/moc_*.h
 gambatte_qt/src/release/
 gambatte_qt/bin/
 test/testrunner
@@ -31,3 +32,6 @@ gambatte_qt/src/platforms.pri
 *.os
 *.so
 *.dll
+*.dylib
+
+.DS_Store

--- a/libgambatte/SConstruct
+++ b/libgambatte/SConstruct
@@ -58,10 +58,23 @@ conf.Finish()
 
 lib = env.Library('gambatte', sourceFiles)
 
+def rev():
+	try:
+		from subprocess import check_output
+		stdout = check_output(['git', 'rev-list', 'HEAD', '--count'])
+		return ' -DREVISION=' + stdout.strip()
+	except:
+		return ' -DREVISION=-1'
+
+import sys
+sys_libs = ['z']
+if sys.platform == 'darwin':
+	sys_libs.append('System')
+
 slib = env.SharedLibrary('gambatte', sourceFiles + ['src/cinterface.cpp'],
-                         CXXFLAGS = env['CXXFLAGS'] + ' -DDLLABLES',
+                         CXXFLAGS = env['CXXFLAGS'] + ' -DDLLABLES' + rev(),
                          LINKFLAGS = env['LINKFLAGS'] + ' -static -s',
-                         LIBS = ['z'])
+                         LIBS = sys_libs)
 
 env.Default(lib)
 env.Alias('slib', slib)

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -239,18 +239,29 @@ public:
 	/**
 	  * Get reg and flag values.
 	  * @param dest length of at least 10, please
+	  *             [pc, sp, a, b, c, d, e, f, h, l]
 	  */
 	void getRegs(int *dest);
+
+	/**
+	  * Set reg and flag values.
+	  * @param src length of at least 10, please
+	  *            [pc, sp, a, b, c, d, e, f, h, l]
+	  */
+	void setRegs(int *src);
 
 	/**
 	  * Sets addresses the CPU will interrupt processing at before the instruction.
 	  * Format is 0xBBAAAA where AAAA is an address and BB is an optional ROM bank.
 	  */
 	void setInterruptAddresses(int *addrs, int numAddrs);
-	
+
 	/** Gets the address the CPU was interrupted at or -1 if stopped normally. */
 	int getHitInterruptAddress();
-    
+
+	/** Returns the current cycle-based time counter as dividers. (2^21/sec) */
+	unsigned timeNow() const;
+
     /** Return a value in range 0-3FFF representing current "position" of internal divider */
     int getDivState();
 

--- a/libgambatte/src/cinterface.cpp
+++ b/libgambatte/src/cinterface.cpp
@@ -23,6 +23,10 @@ namespace {
 
 using namespace gambatte;
 
+GBEXPORT int gambatte_revision() {
+	return REVISION;
+}
+
 GBEXPORT GB * gambatte_create() {
 	return new GB();
 }
@@ -41,6 +45,10 @@ GBEXPORT int gambatte_loadbios(GB *g, char const *biosfile, unsigned size, unsig
 
 GBEXPORT int gambatte_runfor(GB *g, unsigned *videoBuf, int pitch, unsigned *audioBuf, unsigned *samples) {
 	return g->runFor(videoBuf, pitch, audioBuf, *(std::size_t *)samples);
+}
+
+GBEXPORT void gambatte_reset(GB *g) {
+	g->reset();
 }
 
 GBEXPORT void gambatte_setinputgetter(GB *g, InputGetter *getInput, void *p) {
@@ -67,12 +75,20 @@ GBEXPORT void gambatte_getregs(GB *g, int *dest) {
 	g->getRegs(dest);
 }
 
+GBEXPORT void gambatte_setregs(GB *g, int *src) {
+	g->setRegs(src);
+}
+
 GBEXPORT void gambatte_setinterruptaddresses(GB *g, int *addrs, int numAddrs) {
 	g->setInterruptAddresses(addrs, numAddrs);
 }
 
 GBEXPORT int gambatte_gethitinterruptaddress(GB *g) {
 	return g->getHitInterruptAddress();
+}
+
+GBEXPORT unsigned gambatte_timenow(GB *g) {
+	return g->timeNow();
 }
 
 GBEXPORT int gambatte_getdivstate(GB *g) {

--- a/libgambatte/src/cinterface.h
+++ b/libgambatte/src/cinterface.h
@@ -19,6 +19,10 @@
 #ifndef CINTERFACE_H
 #define CINTERFACE_H
 
-#define GBEXPORT extern "C" __declspec(dllexport)
+#ifdef _WIN32
+# define GBEXPORT extern "C" __declspec(dllexport)
+#else
+# define GBEXPORT extern "C"
+#endif
 
 #endif

--- a/libgambatte/src/cpu.cpp
+++ b/libgambatte/src/cpu.cpp
@@ -39,6 +39,7 @@ CPU::CPU()
 , h(0x01)
 , l(0x4D)
 , skip_(false)
+, numInterruptAddresses(0)
 {
 }
 
@@ -2067,6 +2068,21 @@ void CPU::getRegs(int *dest) {
 	dest[7] = toF(hf2, cf, zf);
 	dest[8] = h;
 	dest[9] = l;
+}
+
+void CPU::setRegs(int *src) {
+	pc_ = src[0];
+	sp = src[1];
+	a_ = src[2];
+	b = src[3];
+	c = src[4];
+	d = src[5];
+	e = src[6];
+	zf  =  zfFromF(src[7]);
+	hf2 = hf2FromF(src[7]);
+	cf  =  cfFromF(src[7]);
+	h = src[8];
+	l = src[9];
 }
 
 void CPU::setInterruptAddresses(int *addrs, int numAddrs) {

--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -85,9 +85,12 @@ public:
 	}
 
 	void getRegs(int *dest);
+	void setRegs(int *src);
 	void setInterruptAddresses(int *addrs, int numAddrs);
 	int getHitInterruptAddress();
-    
+
+	unsigned timeNow() const { return mem_.timeNow(cycleCounter_); }
+
     unsigned long getCycleCounter() { return cycleCounter_; }
     unsigned long getDivLastUpdate() { return mem_.getDivLastUpdate(); }
     unsigned char getRawIOAMHRAM(int offset) { return mem_.getRawIOAMHRAM(offset); }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -88,10 +88,10 @@ void GB::reset(std::string const &build) {
 
 		SaveState state;
 		p_->cpu.setStatePtrs(state);
+		p_->cpu.saveState(state);
 		unsigned flags = p_->loadflags;
 		setInitState(state, flags & CGB_MODE, flags & GBA_FLAG, flags & SGB_MODE);
 		p_->cpu.loadState(state);
-		p_->cpu.loadSavedata();
 
 		if (!build.empty())
 			p_->cpu.setOsdElement(newResetElement(build, GB::pakInfo().crc()));
@@ -118,6 +118,7 @@ LoadRes GB::load(std::string const &romfile, unsigned const flags) {
 		p_->cpu.setStatePtrs(state);
 		p_->loadflags = flags;
 		setInitState(state, flags & CGB_MODE, flags & GBA_FLAG, flags & SGB_MODE);
+		setInitStateCart(state);
 		p_->cpu.loadState(state);
 		p_->cpu.loadSavedata();
 
@@ -305,12 +306,20 @@ void GB::getRegs(int *dest) {
 	p_->cpu.getRegs(dest);
 }
 
+void GB::setRegs(int *src) {
+	p_->cpu.setRegs(src);
+}
+
 void GB::setInterruptAddresses(int *addrs, int numAddrs) {
 	p_->cpu.setInterruptAddresses(addrs, numAddrs);
 }
 
 int GB::getHitInterruptAddress() {
 	return p_->cpu.getHitInterruptAddress();
+}
+
+unsigned GB::timeNow() const {
+	return p_->cpu.timeNow();
 }
 
 int GB::getDivState() {

--- a/libgambatte/src/initstate.cpp
+++ b/libgambatte/src/initstate.cpp
@@ -1169,6 +1169,8 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
 		0x83, 0x40, 0x0B, 0x77
 	};
 
+	unsigned long cc = state.cpu.cycleCounter;
+
 	state.cpu.cycleCounter = 8;
 	state.cpu.pc = 0;
 	state.cpu.sp = 0;
@@ -1184,8 +1186,6 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
 	state.mem.biosMode = true;
 	state.mem.cgbSwitching = false;
 	state.mem.agbFlag = cgb && agb;
-
-	std::memset(state.mem.sram.ptr, 0xFF, state.mem.sram.size());
 
 	setInitialVram(state.mem.vram.ptr, cgb);
 
@@ -1346,10 +1346,7 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
 	state.spu.ch4.nr4 = 0;
 	state.spu.ch4.master = false;
 
-	state.time.seconds = 0;
-	state.time.lastTimeSec = Time::now().tv_sec;
-	state.time.lastTimeUsec = Time::now().tv_usec;
-	state.time.lastCycles = state.cpu.cycleCounter;
+	state.time.lastCycles = state.time.lastCycles - (cc - state.cpu.cycleCounter);
 
 	state.rtc.haltTime = state.time.seconds;
 	state.rtc.dataDh = 0;
@@ -1366,4 +1363,13 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const agb, bo
     state.huc3.shift = 0;
     state.huc3.ramValue = 1;
     state.huc3.modeflag = 2; // huc3_none
+}
+
+void gambatte::setInitStateCart(SaveState &state) {
+	std::memset(state.mem.sram.ptr, 0xFF, state.mem.sram.size());
+
+	state.time.seconds = 0;
+	state.time.lastTimeSec = Time::now().tv_sec;
+	state.time.lastTimeUsec = Time::now().tv_usec;
+	state.time.lastCycles = state.cpu.cycleCounter;
 }

--- a/libgambatte/src/initstate.h
+++ b/libgambatte/src/initstate.h
@@ -22,6 +22,7 @@
 namespace gambatte {
 
 void setInitState(struct SaveState &state, bool cgb, bool agb, bool sgb);
+void setInitStateCart(struct SaveState &state);
 
 }
 

--- a/libgambatte/src/mem/cartridge.h
+++ b/libgambatte/src/mem/cartridge.h
@@ -67,6 +67,7 @@ public:
 	void resetCc(unsigned long const oldCc, unsigned long const newCc) { time_.resetCc(oldCc, newCc); }
 	void speedChange(unsigned long const cc) { time_.speedChange(cc); }
 	void setTimeMode(bool useCycles, unsigned long const cc) { time_.setTimeMode(useCycles, cc); }
+	unsigned timeNow(unsigned long const cc) const { return time_.timeNow(cc); }
 	void rtcWrite(unsigned data, unsigned long const cc) { rtc_.write(data, cc); }
 	unsigned char rtcRead() const { return *rtc_.activeData(); }
 	void loadSavedata(unsigned long cycleCounter);

--- a/libgambatte/src/mem/time.h
+++ b/libgambatte/src/mem/time.h
@@ -48,6 +48,8 @@ public:
 	void setBaseTime(timeval baseTime, unsigned long cycleCounter);
 	void setTimeMode(bool useCycles, unsigned long cycleCounter);
 
+	unsigned timeNow(unsigned long cycleCounter) const;
+
 private:
 	std::time_t seconds_;
 	timeval lastTime_;

--- a/libgambatte/src/memory.h
+++ b/libgambatte/src/memory.h
@@ -152,7 +152,9 @@ public:
 		biosSize_ = size;
 	}
 	bool gbIsCgb() { return gbIsCgb_; }
-    
+
+	unsigned timeNow(unsigned long const cc) const { return cart_.timeNow(cc); }
+
     unsigned long getDivLastUpdate() { return divLastUpdate_; }
     unsigned char getRawIOAMHRAM(int offset) { return ioamhram_[offset]; }
 

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -36,6 +36,7 @@ struct SaveState {
 
 		friend class SaverList;
 		friend void setInitState(SaveState &, bool, bool, bool);
+		friend void setInitStateCart(SaveState &);
 
 	private:
 		T *ptr;

--- a/libgambatte/src/video/ppu.cpp
+++ b/libgambatte/src/video/ppu.cpp
@@ -1513,6 +1513,7 @@ PPUPriv::PPUPriv(NextM0Time &nextM0Time, unsigned char const *const oamram, unsi
 , endx(0)
 , cgb(false)
 , weMaster(false)
+, trueColors(false)
 {
 	std::memset(spriteList, 0, sizeof spriteList);
 	std::memset(spwordList, 0, sizeof spwordList);


### PR DESCRIPTION
- new things: gambatte_revision, gambatte_reset, gambatte_setregs, gambatte_timenow
- included entrpntr's changes to build on mac
- reset is now (should be) persistent with cartridge-y values
- other minor cleanup
